### PR TITLE
add deprecation notice pointing to ignition-guides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,9 @@
 # Git Style Guide
 
 > [!IMPORTANT]
-> This content has moved. The Git Style Guide content from this repository is now part of [ignition-guides](https://ia-eknorr.github.io/ignition-guides/), the modern community resource for DevOps workflows with Ignition.
+> This repository is archived. The Git Style Guide content has moved to [ignition-guides](https://ia-eknorr.github.io/ignition-guides/), the community resource for modern DevOps workflows with Ignition.
 >
 > Go directly to: **[Git Style Guide](https://ia-eknorr.github.io/ignition-guides/docs/reference/git-style-guide)**
->
-> This repository will be archived once the linked forum post is updated.
 
 ## Table of Contents
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,12 @@
 # Git Style Guide
 
+> [!IMPORTANT]
+> This content has moved. The Git Style Guide content from this repository is now part of [ignition-guides](https://ia-eknorr.github.io/ignition-guides/), the modern community resource for DevOps workflows with Ignition.
+>
+> Go directly to: **[Git Style Guide](https://ia-eknorr.github.io/ignition-guides/docs/reference/git-style-guide)**
+>
+> This repository will be archived once the linked forum post is updated.
+
 ## Table of Contents
 
 - [Git Style Guide](#git-style-guide)


### PR DESCRIPTION
The Git Style Guide content from this repo has been merged into [ignition-guides](https://ia-eknorr.github.io/ignition-guides/). This PR adds an obvious banner at the top of the README so anyone landing here via the [forum post](https://forum.inductiveautomation.com/t/guide-for-version-control-with-ignition/84004) gets redirected to the new home.

This repo will be archived once the forum post is updated.