### PR TITLE
fix: repoint archived guide banner to knorrlabs.github.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # Git Style Guide
 
 > [!IMPORTANT]
-> This repository is archived. The Git Style Guide content has moved to [ignition-guides](https://ia-eknorr.github.io/ignition-guides/), the community resource for modern DevOps workflows with Ignition.
+> This repository is archived. The Git Style Guide content has moved to [ignition-guides](https://knorrlabs.github.io/ignition-guides/), the community resource for modern DevOps workflows with Ignition.
 >
-> Go directly to: **[Git Style Guide](https://ia-eknorr.github.io/ignition-guides/docs/reference/git-style-guide)**
+> Go directly to: **[Git Style Guide](https://knorrlabs.github.io/ignition-guides/docs/reference/git-style-guide)**
 
 ## Table of Contents
 


### PR DESCRIPTION
The archived README banner linked to ia-eknorr.github.io/ignition-guides (now 404 after the account rename + org move). Repoint both links to knorrlabs.github.io/ignition-guides. Direct commit was blocked by this repo's main ruleset, so applying via PR.